### PR TITLE
Update l2_interfaces.py

### DIFF
--- a/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -49,7 +49,7 @@ class L2_InterfacesFacts(object):
         objs = []
 
         if not data:
-            data = connection.get('show running-config | section ^interface')
+            data = connection.get('show running-config | include interface|description|switchport')
         # operate on a collection of resource x
         config = data.split('interface ')
         for conf in config:

--- a/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -49,7 +49,7 @@ class L2_InterfacesFacts(object):
         objs = []
 
         if not data:
-            data = connection.get('show running-config | include interface|description|switchport')
+            data = connection.get('show running-config | include ^interface|description|switchport')
         # operate on a collection of resource x
         config = data.split('interface ')
         for conf in config:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes line 52 from "show running-config | section ^interface" to "show running-config | include interface|description|switchport" 

This provides backwards compatibility for cisco IOS devices running code that does not support the " | section " command.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
